### PR TITLE
Update RAG Made Simple promotion pricing to $9.99

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Welcome to one of the most extensive and dynamic collections of Generative AI (G
 <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--readme&click=book-buy-amazon-image&target=https%3A%2F%2Fwww.amazon.com%2Fdp%2FB0D76734SZ%3Ftag%3Ddiamantai-genai-20&text=Best%20Seller%20Image"><img src="images/rag_book_best_seller.png" alt="#1 Best Seller in Generative AI on Amazon - Click to buy" width="500"></a>
 
 **[RAG Made Simple](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--readme&click=book-buy-amazon-title&target=https%3A%2F%2Fwww.amazon.com%2Fdp%2FB0D76734SZ%3Ftag%3Ddiamantai-genai-20&text=RAG%20Made%20Simple)** — **#1 Best Seller on Amazon in Generative AI.**
-22 RAG techniques with intuition, comparisons, and illustrations. **Free with Kindle Unlimited** or **$0.99** launch price (goes up soon).
+22 RAG techniques with intuition, comparisons, and illustrations. **Free with Kindle Unlimited** or **$9.99** on Amazon.
 
 ### 👉 [**Get the book on Amazon**](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--readme&click=book-buy-amazon-cta&target=https%3A%2F%2Fwww.amazon.com%2Fdp%2FB0D76734SZ%3Ftag%3Ddiamantai-genai-20&text=Get%20the%20book%20on%20Amazon)
 


### PR DESCRIPTION
Removes the now-stale "$0.99 launch price" messaging and updates the
RAG Made Simple promotion to reflect its current steady-state price
of $9.99 (free with Kindle Unlimited).

The book launched at $0.99 on April 9 as a rank-buying promotional
period. The price was raised to $9.99 on April 13. Existing README
copy was still showing the $0.99 launch price and time-limited urgency
language ("price goes up soon", "before the price changes"), which is
no longer accurate.

Changes are minimal and surgical. No structural changes to the README.
The existing book promotion section retains its layout, image, click-
tracker URL, and Amazon Associates affiliate tag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated "RAG Made Simple" pricing to $9.99 on Amazon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->