### PR TITLE
Add affiliate CTA for content creators

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Welcome to one of the most extensive and dynamic collections of Generative AI (G
 
 👉 [**Get RAG Made Simple (33% off with code RAGKING)**](https://diamant-ai.com/rag-made-simple?code=RAGKING)
 
+📣 *Teach, write, or run a dev community? Earn 30% recommending RAG Made Simple to your audience: [become an affiliate](https://nirdiamant.gumroad.com/affiliates).*
+
 ---
 
 **[Prompt Engineering: Master the Art of AI Interaction](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--readme&click=book-buy-pe&target=https%3A%2F%2Fwww.amazon.com%2Fdp%2FB0DZ85RPB5%3Ftag%3Ddiamantai-genai-20&text=Prompt%20Engineering)** - the prompting foundation


### PR DESCRIPTION
Adds a targeted affiliate-recruitment line under the existing book CTA. Framed for people with their own audience (educators, writers, community leaders) so it self-selects promoters rather than waving a discount at direct buyers. Signup: https://nirdiamant.gumroad.com/affiliates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with new affiliate program details, including information about recommending services and revenue sharing opportunities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->