### PR TITLE
Track affiliate link via click-tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Welcome to one of the most extensive and dynamic collections of Generative AI (G
 
 👉 [**Get RAG Made Simple (33% off with code RAGKING)**](https://diamant-ai.com/rag-made-simple?code=RAGKING)
 
-📣 *Teach, write, or run a dev community? Earn 30% recommending RAG Made Simple to your audience: [become an affiliate](https://nirdiamant.gumroad.com/affiliates).*
+📣 *Teach, write, or run a dev community? Earn 30% recommending RAG Made Simple to your audience: [become an affiliate](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--readme&click=affiliate-signup&target=https%3A%2F%2Fnirdiamant.gumroad.com%2Faffiliates&retarget=0&text=become%20an%20affiliate).*
 
 ---
 


### PR DESCRIPTION
Routes the affiliate CTA through the existing click-tracker for per-repo signup attribution. Clean 302 (retarget=0), no user-facing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the affiliate sponsorship link in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->