### PR TITLE
Add 'Read Chapter 1 free' link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Welcome to one of the most extensive and dynamic collections of Generative AI (G
 
 👉 [**Get RAG Made Simple (33% off with code RAGKING)**](https://diamant-ai.com/rag-made-simple?code=RAGKING)
 
+📖 *Not ready to buy? [**Read Chapter 1 free**](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--readme&click=free-chapter&target=https%3A%2F%2Fdiamant-ai.com%2Frag-made-simple%2Fchapter-1&retarget=0&text=read%20chapter%201%20free) - the full first chapter, no signup.*
+
 📣 *Teach, write, or run a dev community? Earn 25% recommending RAG Made Simple to your audience: [become an affiliate](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--readme&click=affiliate-signup&target=https%3A%2F%2Fnirdiamant.gumroad.com%2Faffiliates&retarget=0&text=become%20an%20affiliate).*
 
 ---


### PR DESCRIPTION
Adds a tracked 'Read Chapter 1 free' link under the book CTA, funneling repo readers into the sampling -> buy flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a "Read Chapter 1 free" link to the RAG Made Simple section of the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->