### PR TITLE
Add MiniMax provider branch to project manager agent

### DIFF
--- a/all_agents_tutorials/project_manager_assistant_agent.ipynb
+++ b/all_agents_tutorials/project_manager_assistant_agent.ipynb
@@ -254,7 +254,15 @@
     "load_dotenv(override=True)\n",
     "\n",
     "# Define your model provider\n",
-    "model_provider = 'Azure' # 'Azure' or 'OpenAI'"
+    "model_provider = 'Azure' # 'Azure', 'OpenAI' or 'MiniMax'",
+    "\n",
+    "# MiniMax provider configuration (OpenAI-compatible API).\n",
+    "# Set MINIMAX_API_KEY in your environment. Use the global or CN endpoint below.\n",
+    "MINIMAX_BASE_URL = os.getenv(\n",
+    "    'MINIMAX_BASE_URL',\n",
+    "    'https://api.minimax.io/v1',  # global endpoint; use https://api.minimaxi.com/v1 for CN\n",
+    ")\n",
+    "MINIMAX_MODEL = os.getenv('MINIMAX_MODEL', 'MiniMax-M3')  # 'MiniMax-M3' or 'MiniMax-M2.7'\n"
    ]
   },
   {
@@ -288,6 +296,21 @@
     "        - OPENAI_API_BASE\n",
     "    \"\"\"\n",
     "    llm = ChatOpenAI(model=\"gpt-4o-mini\")\n",
+    "elif model_provider == 'MiniMax':\n",
+    "    \"\"\"\n",
+    "    Define your environmental variables under .venv:\n",
+    "        - MINIMAX_API_KEY\n",
+    "        - MINIMAX_BASE_URL (optional, defaults to the global endpoint)\n",
+    "        - MINIMAX_MODEL (optional, defaults to MiniMax-M3)\n",
+    "    MiniMax exposes an OpenAI-compatible API, so ChatOpenAI can be reused\n",
+    "    by pointing it at the MiniMax base URL with the desired model id\n",
+    "    (MiniMax-M3 or MiniMax-M2.7).\n",
+    "    \"\"\"\n",
+    "    llm = ChatOpenAI(\n",
+    "        model=MINIMAX_MODEL,\n",
+    "        base_url=MINIMAX_BASE_URL,\n",
+    "        api_key=os.getenv('MINIMAX_API_KEY'),\n",
+    "    )\n",
     "else:\n",
     "    print('Implement your own llm loader')"
    ]


### PR DESCRIPTION
Reason: Add a MiniMax OpenAI-compatible branch to the project manager agent's model_provider switch so users no longer need to implement their own loader.

## Changes
- Extend the `model_provider` switch in `all_agents_tutorials/project_manager_assistant_agent.ipynb` with a `MiniMax` branch that reuses `ChatOpenAI` against the MiniMax OpenAI-compatible base URL.
- Add `MINIMAX_BASE_URL` (defaults to the global endpoint `https://api.minimax.io/v1`; the CN endpoint `https://api.minimaxi.com/v1` is documented for regional use) and `MINIMAX_MODEL` (defaults to `MiniMax-M3`, with `MiniMax-M2.7` as an alternative model id).
- The `MiniMax` branch loads `MINIMAX_API_KEY` from the environment, matching the existing Azure/OpenAI env-driven pattern.

## Checks
- Notebook JSON validated with `python -m json.tool`.
- Secret scan of the diff produced no matches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added MiniMax as a selectable language model provider in the project manager assistant tutorial.
  - Added configuration options for the MiniMax API endpoint and model.
  - Enabled authentication through a MiniMax API key.
  - Supports MiniMax’s OpenAI-compatible interface for generating assistant responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->