### PR TITLE
Tracked video section + tutorial-index landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,18 +68,24 @@ One `npm install` adds the module's AI assistant to your Claude Code, and it gui
 <table>
 <tr>
 <td width="33%" align="center" valign="top">
-  <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--readme&click=youtube-readme-llm&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DtKXvKKVQ1Dc&retarget=0&text=youtube-readme-llm"><img src="https://img.youtube.com/vi/tKXvKKVQ1Dc/mqdefault.jpg" width="100%" alt="How LLMs Actually Work (and Why AI Makes Things Up)"></a><br>
-  <b><a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--readme&click=youtube-readme-llm&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DtKXvKKVQ1Dc&retarget=0&text=youtube-readme-llm">How LLMs Actually Work (and Why AI Makes Things Up)</a></b><br>
+  <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--readme&amp;click=youtube-readme-llm&amp;target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DtKXvKKVQ1Dc&amp;retarget=0&amp;text=youtube-readme-llm">
+    <img src="https://img.youtube.com/vi/tKXvKKVQ1Dc/mqdefault.jpg" width="100%" alt="">
+    <br><b>How LLMs Actually Work (and Why AI Makes Things Up)</b>
+  </a><br>
   <sub>recalling a fact and inventing one are literally the same move</sub>
 </td>
 <td width="33%" align="center" valign="top">
-  <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--readme&click=youtube-readme-ctx&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3Da7bteK6c3Ng&retarget=0&text=youtube-readme-ctx"><img src="https://img.youtube.com/vi/a7bteK6c3Ng/mqdefault.jpg" width="100%" alt="Context Is the New Code"></a><br>
-  <b><a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--readme&click=youtube-readme-ctx&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3Da7bteK6c3Ng&retarget=0&text=youtube-readme-ctx">Context Is the New Code</a></b><br>
+  <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--readme&amp;click=youtube-readme-ctx&amp;target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3Da7bteK6c3Ng&amp;retarget=0&amp;text=youtube-readme-ctx">
+    <img src="https://img.youtube.com/vi/a7bteK6c3Ng/mqdefault.jpg" width="100%" alt="">
+    <br><b>Context Is the New Code</b>
+  </a><br>
   <sub>the shift from writing the code to shaping what the model sees</sub>
 </td>
 <td width="33%" align="center" valign="top">
-  <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--readme&click=youtube-readme-cc&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3D0fU8GdipOjc&retarget=0&text=youtube-readme-cc"><img src="https://img.youtube.com/vi/0fU8GdipOjc/mqdefault.jpg" width="100%" alt="Stop Thinking Claude Code Is Magic. Here's How It Works"></a><br>
-  <b><a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--readme&click=youtube-readme-cc&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3D0fU8GdipOjc&retarget=0&text=youtube-readme-cc">Stop Thinking Claude Code Is Magic. Here's How It Works</a></b><br>
+  <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--readme&amp;click=youtube-readme-cc&amp;target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3D0fU8GdipOjc&amp;retarget=0&amp;text=youtube-readme-cc">
+    <img src="https://img.youtube.com/vi/0fU8GdipOjc/mqdefault.jpg" width="100%" alt="">
+    <br><b>Stop Thinking Claude Code Is Magic. Here's How It Works</b>
+  </a><br>
   <sub>what the agent loop is actually doing on every turn</sub>
 </td>
 </tr>

--- a/README.md
+++ b/README.md
@@ -59,6 +59,36 @@ One `npm install` adds the module's AI assistant to your Claude Code, and it gui
 
 [![DiamantAI's newsletter](images/substack_image.png)](https://newsletter.diamant-ai.com/?r=336pe4&utm_campaign=pub-share-checklist)
 
+<h2 align="center">🎬 Prefer video?</h2>
+
+<div align="center">
+
+*I break these ideas down into short, one-idea-per-episode explainers on YouTube.*
+
+<table>
+<tr>
+<td width="33%" align="center" valign="top">
+  <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--readme&click=youtube-readme-llm&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DtKXvKKVQ1Dc&retarget=0&text=youtube-readme-llm"><img src="https://img.youtube.com/vi/tKXvKKVQ1Dc/mqdefault.jpg" width="100%" alt="How LLMs Actually Work (and Why AI Makes Things Up)"></a><br>
+  <b><a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--readme&click=youtube-readme-llm&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DtKXvKKVQ1Dc&retarget=0&text=youtube-readme-llm">How LLMs Actually Work (and Why AI Makes Things Up)</a></b><br>
+  <sub>recalling a fact and inventing one are literally the same move</sub>
+</td>
+<td width="33%" align="center" valign="top">
+  <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--readme&click=youtube-readme-ctx&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3Da7bteK6c3Ng&retarget=0&text=youtube-readme-ctx"><img src="https://img.youtube.com/vi/a7bteK6c3Ng/mqdefault.jpg" width="100%" alt="Context Is the New Code"></a><br>
+  <b><a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--readme&click=youtube-readme-ctx&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3Da7bteK6c3Ng&retarget=0&text=youtube-readme-ctx">Context Is the New Code</a></b><br>
+  <sub>the shift from writing the code to shaping what the model sees</sub>
+</td>
+<td width="33%" align="center" valign="top">
+  <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--readme&click=youtube-readme-cc&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3D0fU8GdipOjc&retarget=0&text=youtube-readme-cc"><img src="https://img.youtube.com/vi/0fU8GdipOjc/mqdefault.jpg" width="100%" alt="Stop Thinking Claude Code Is Magic. Here's How It Works"></a><br>
+  <b><a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--readme&click=youtube-readme-cc&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3D0fU8GdipOjc&retarget=0&text=youtube-readme-cc">Stop Thinking Claude Code Is Magic. Here's How It Works</a></b><br>
+  <sub>what the agent loop is actually doing on every turn</sub>
+</td>
+</tr>
+</table>
+
+[![Subscribe on YouTube](https://img.shields.io/youtube/channel/subscribers/UCatj5F2gohksvfNmnEpRnNA?style=social)](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--readme&click=youtube-subscribe-channel&target=https%3A%2F%2Fwww.youtube.com%2F%40DiamantAI%3Fsub_confirmation%3D1&retarget=0&text=youtube-subscribe-channel) &nbsp; [**Browse every episode →**](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--readme&click=youtube-all-episodes&target=https%3A%2F%2Fwww.youtube.com%2F%40DiamantAI&retarget=0&text=youtube-all-episodes)
+
+</div>
+
 ## Introduction
 
 Generative AI agents are at the forefront of artificial intelligence, revolutionizing the way we interact with and leverage AI technologies. This repository is designed to guide you through the development journey, from basic agent implementations to advanced, cutting-edge systems.

--- a/all_agents_tutorials/README.md
+++ b/all_agents_tutorials/README.md
@@ -1,0 +1,43 @@
+<div align="center">
+
+## GenAI Agents - tutorial index
+
+Building agents starts with understanding what the model underneath is actually doing.
+
+</div>
+
+### 🎬 Watch the ideas explained
+
+<table>
+<tr>
+<td width="33%" align="center" valign="top">
+  <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--tutorials-index&click=youtube-index-llm&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DtKXvKKVQ1Dc&retarget=0&text=youtube-index-llm"><img src="https://img.youtube.com/vi/tKXvKKVQ1Dc/mqdefault.jpg" width="100%" alt="How LLMs Actually Work (and Why AI Makes Things Up)"></a><br>
+  <b><a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--tutorials-index&click=youtube-index-llm&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DtKXvKKVQ1Dc&retarget=0&text=youtube-index-llm">How LLMs Actually Work (and Why AI Makes Things Up)</a></b><br>
+  <sub>recalling a fact and inventing one are literally the same move</sub>
+</td>
+<td width="33%" align="center" valign="top">
+  <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--tutorials-index&click=youtube-index-ctx&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3Da7bteK6c3Ng&retarget=0&text=youtube-index-ctx"><img src="https://img.youtube.com/vi/a7bteK6c3Ng/mqdefault.jpg" width="100%" alt="Context Is the New Code"></a><br>
+  <b><a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--tutorials-index&click=youtube-index-ctx&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3Da7bteK6c3Ng&retarget=0&text=youtube-index-ctx">Context Is the New Code</a></b><br>
+  <sub>the shift from writing the code to shaping what the model sees</sub>
+</td>
+<td width="33%" align="center" valign="top">
+  <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--tutorials-index&click=youtube-index-cc&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3D0fU8GdipOjc&retarget=0&text=youtube-index-cc"><img src="https://img.youtube.com/vi/0fU8GdipOjc/mqdefault.jpg" width="100%" alt="Stop Thinking Claude Code Is Magic. Here's How It Works"></a><br>
+  <b><a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--tutorials-index&click=youtube-index-cc&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3D0fU8GdipOjc&retarget=0&text=youtube-index-cc">Stop Thinking Claude Code Is Magic. Here's How It Works</a></b><br>
+  <sub>what the agent loop is actually doing on every turn</sub>
+</td>
+</tr>
+</table>
+
+<div align="center">
+
+[![Subscribe on YouTube](https://img.shields.io/youtube/channel/subscribers/UCatj5F2gohksvfNmnEpRnNA?style=social)](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--tutorials-index&click=youtube-subscribe-channel&target=https%3A%2F%2Fwww.youtube.com%2F%40DiamantAI%3Fsub_confirmation%3D1&retarget=0&text=youtube-subscribe-channel) &nbsp; [**Browse every episode →**](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--tutorials-index&click=youtube-all-episodes&target=https%3A%2F%2Fwww.youtube.com%2F%40DiamantAI&retarget=0&text=youtube-all-episodes)
+
+</div>
+
+---
+
+<div align="center">
+
+**[← Back to the main README](../README.md)** for the full technique table, the book and the course.
+
+</div>

--- a/all_agents_tutorials/README.md
+++ b/all_agents_tutorials/README.md
@@ -11,18 +11,24 @@ Building agents starts with understanding what the model underneath is actually 
 <table>
 <tr>
 <td width="33%" align="center" valign="top">
-  <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--tutorials-index&click=youtube-index-llm&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DtKXvKKVQ1Dc&retarget=0&text=youtube-index-llm"><img src="https://img.youtube.com/vi/tKXvKKVQ1Dc/mqdefault.jpg" width="100%" alt="How LLMs Actually Work (and Why AI Makes Things Up)"></a><br>
-  <b><a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--tutorials-index&click=youtube-index-llm&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DtKXvKKVQ1Dc&retarget=0&text=youtube-index-llm">How LLMs Actually Work (and Why AI Makes Things Up)</a></b><br>
+  <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--tutorials-index&amp;click=youtube-index-llm&amp;target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DtKXvKKVQ1Dc&amp;retarget=0&amp;text=youtube-index-llm">
+    <img src="https://img.youtube.com/vi/tKXvKKVQ1Dc/mqdefault.jpg" width="100%" alt="">
+    <br><b>How LLMs Actually Work (and Why AI Makes Things Up)</b>
+  </a><br>
   <sub>recalling a fact and inventing one are literally the same move</sub>
 </td>
 <td width="33%" align="center" valign="top">
-  <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--tutorials-index&click=youtube-index-ctx&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3Da7bteK6c3Ng&retarget=0&text=youtube-index-ctx"><img src="https://img.youtube.com/vi/a7bteK6c3Ng/mqdefault.jpg" width="100%" alt="Context Is the New Code"></a><br>
-  <b><a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--tutorials-index&click=youtube-index-ctx&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3Da7bteK6c3Ng&retarget=0&text=youtube-index-ctx">Context Is the New Code</a></b><br>
+  <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--tutorials-index&amp;click=youtube-index-ctx&amp;target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3Da7bteK6c3Ng&amp;retarget=0&amp;text=youtube-index-ctx">
+    <img src="https://img.youtube.com/vi/a7bteK6c3Ng/mqdefault.jpg" width="100%" alt="">
+    <br><b>Context Is the New Code</b>
+  </a><br>
   <sub>the shift from writing the code to shaping what the model sees</sub>
 </td>
 <td width="33%" align="center" valign="top">
-  <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--tutorials-index&click=youtube-index-cc&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3D0fU8GdipOjc&retarget=0&text=youtube-index-cc"><img src="https://img.youtube.com/vi/0fU8GdipOjc/mqdefault.jpg" width="100%" alt="Stop Thinking Claude Code Is Magic. Here's How It Works"></a><br>
-  <b><a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--tutorials-index&click=youtube-index-cc&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3D0fU8GdipOjc&retarget=0&text=youtube-index-cc">Stop Thinking Claude Code Is Magic. Here's How It Works</a></b><br>
+  <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=genai-agents--tutorials-index&amp;click=youtube-index-cc&amp;target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3D0fU8GdipOjc&amp;retarget=0&amp;text=youtube-index-cc">
+    <img src="https://img.youtube.com/vi/0fU8GdipOjc/mqdefault.jpg" width="100%" alt="">
+    <br><b>Stop Thinking Claude Code Is Magic. Here's How It Works</b>
+  </a><br>
   <sub>what the agent loop is actually doing on every turn</sub>
 </td>
 </tr>


### PR DESCRIPTION
## Why

This repo sends **nothing** to the YouTube channel today. 23,573 stars, 10,313 pageviews/14d, and no video CTA on the live README at all.

The pattern is already proven next door. On RAG_Techniques, normalising `clicks_by_link` to **clicks per day live**, the video links out-pull the entire nine-link book stack (**38.0/day vs 37.7**). The CTA isn't weak — it's simply missing from every surface but one repo.

The slot even exists here: the 2024 hackathon tutorials carry `**YouTube Explanation**` lines. It's just been empty for everything since.

## What changed

**1. A dedicated "Prefer video?" section** above `## Introduction`, with real YouTube thumbnails via `img.youtube.com` (no repo bloat) so it carries a play affordance rather than being a text link.

**2. `all_agents_tutorials/README.md`** — new. GitHub renders a directory README beneath the file listing, and `/tree/main/all_agents_tutorials` takes **500 views/14d with no call to action.** These are people already browsing the tutorial index.

Episodes picked for topical fit (foundations under agent-building), not per-tutorial mapping — no video↔notebook claim is made that isn't real.

## Measurement

Links route through **`rag-techniques-tracker`** with `notebook=genai-agents--readme` / `--tutorials-index`, matching how this repo's book and course CTAs already work. Worth flagging: the **`genai-agents-tracker` 400s on a `youtube.com` target** — it isn't allowlisted, so routing video links there would have shipped dead links.

All URLs curl-tested → `302` to the correct watch page.

## Note on your local WIP

You had 4 uncommitted lines in `README.md` on `main` adding an untracked version of this CTA. Superseded here and saved in `git stash`; `.pr_agent.toml` left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a “Prefer video?” section with three YouTube episode cards, descriptions, and links.
  * Added a GenAI agents tutorial index featuring three tutorial videos and navigation links.
  * Included subscription and browse options for video content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->