### PR TITLE
Add a temporal memory agent tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Below is a comprehensive overview of our GenAI agent implementations, organized 
 | 50 | 💼 **Business**   | [Contextual Quoting System](all_agents_tutorials/contextual_quoting_agentic_system.ipynb) | LangGraph  | Multi-agent quoting, RAG + structured data                                   |
 | 51 | 📊 **Analysis**   | [Document Intake Agent](all_agents_tutorials/document_intake_agent_langgraph.ipynb) | LangGraph  | Office docs to LLM-ready markdown, conversion as a tool call                 |
 | 52 | 🎨 **Creative**   | [Social Media Publishing Agent](all_agents_tutorials/social_media_publishing_agent_publora_langgraph.ipynb) | LangGraph  | Per-platform generation, self-review loop, publishing via Publora API        |
+| 53 | 📊 **Analysis**   | [Temporal Memory Agent](all_agents_tutorials/temporal_memory_agent.ipynb) | Lians SDK | Current vs point-in-time recall, durable corrections, verifiable receipts    |
 
 Explore our extensive list of GenAI agent implementations, sorted by categories:
 
@@ -731,6 +732,14 @@ Explore our extensive list of GenAI agent implementations, sorted by categories:
 
     #### Implementation 🛠️
     A LangGraph workflow (fetch_connections → generate → review → publish) with a bounded revise loop: a deterministic length check plus an LLM critic send failing drafts back to the generator with targeted feedback. Publishing goes through Publora's REST API (one create-post call per platform, each with an idempotency key so a call's network retry is safe), with a dry-run mode that creates drafts so nothing goes live while experimenting.
+
+53. **[Temporal Memory Agent with Local Point-in-Time Recall](https://github.com/NirDiamant/GenAI_Agents/blob/main/all_agents_tutorials/temporal_memory_agent.ipynb)**
+
+    #### Overview 🔎
+    A provider-neutral memory tool that lets an AI agent answer both what is true now and what was known at a historical cutoff. The tutorial runs locally with SQLite and no API key, then demonstrates a shipping-estimate correction without leaking future information into the historical answer.
+
+    #### Implementation 🛠️
+    Uses the Lians local Python SDK to store event-time facts with stable entity and field metadata. A small framework-neutral agent wrapper performs current or point-in-time recall, while executable assertions verify correction semantics and independently recompute each retrieval receipt's SHA-256 digest.
 
 ### 🌟 Special Advanced Technique 🌟
 

--- a/all_agents_tutorials/temporal_memory_agent.ipynb
+++ b/all_agents_tutorials/temporal_memory_agent.ipynb
@@ -1,0 +1,316 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Temporal Memory Agent with Local Point-in-Time Recall\n",
+    "\n",
+    "AI agents often overwrite a fact when the world changes. That makes today's answer correct, but it makes questions such as *What did the agent know on Sunday?* impossible to answer honestly.\n",
+    "\n",
+    "This tutorial builds a small, provider-neutral agent memory tool that:\n",
+    "\n",
+    "- runs locally with SQLite and no API key;\n",
+    "- stores facts using their real event time;\n",
+    "- separates current recall from point-in-time recall; and\n",
+    "- returns a receipt whose hash can be verified independently.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Why a timeline matters\n",
+    "\n",
+    "Suppose a support agent learns on Friday that an order will ship Friday. On Sunday, the estimate changes to Monday. A normal vector store may retrieve both statements or whichever text is most similar. A temporal memory should answer **Monday now** and **Friday as of Sunday morning**, without leaking the later correction backward in time.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Architecture\n",
+    "\n",
+    "![Temporal memory agent architecture](../images/temporal-memory-agent.svg)\n",
+    "\n",
+    "The agent can be powered by any model or orchestration framework. Memory is a separate tool: the agent writes facts and asks for either the current state or the state at a supplied timestamp.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Install the local SDK\n",
+    "\n",
+    "The local extra includes the SQLite engine. This tutorial explicitly selects Lians' deterministic local embedding provider so the example is reproducible and does not download a model. Use the default sentence-transformers provider for real semantic retrieval.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install \"lians-sdk[local]==0.5.0\" \"nest-asyncio>=1.6\" -q"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Import the small set of dependencies\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from __future__ import annotations\n",
+    "\n",
+    "import hashlib\n",
+    "import json\n",
+    "import tempfile\n",
+    "from datetime import UTC, datetime\n",
+    "from pathlib import Path\n",
+    "from typing import Any\n",
+    "\n",
+    "import nest_asyncio\n",
+    "from lians import LocalLiansClient\n",
+    "\n",
+    "nest_asyncio.apply()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create an isolated local memory\n",
+    "\n",
+    "A file-backed database makes memory durable across agent sessions. A temporary directory keeps this tutorial repeatable. In an application, replace the path with a stable location such as `~/.my-agent/memory.db`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "temp_dir = tempfile.TemporaryDirectory()\n",
+    "memory = LocalLiansClient(\n",
+    "    db_path=Path(temp_dir.name) / \"agent-memory.db\",\n",
+    "    embedding_provider=\"local\",\n",
+    ")\n",
+    "\n",
+    "AGENT_ID = \"shipping-support-agent\"\n",
+    "FACT_FILTER = {\"entity\": \"order-1842\", \"field\": \"shipping_estimate\"}\n",
+    "QUERY = \"When will order 1842 ship?\"\n",
+    "SUNDAY_MORNING = datetime(2026, 8, 2, 12, tzinfo=UTC)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Store the correction as a timeline\n",
+    "\n",
+    "The Monday correction is deliberately inserted first. Correct recall must depend on `event_time`, not insertion order. The shared entity and field metadata tell the memory engine that both records describe successive values of the same fact.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "memory.add(\n",
+    "    agent_id=AGENT_ID,\n",
+    "    content=\"Order 1842 shipping estimate changed to Monday\",\n",
+    "    event_time=datetime(2026, 8, 2, 15, tzinfo=UTC),\n",
+    "    metadata=FACT_FILTER,\n",
+    "    source=\"synthetic-order-event\",\n",
+    ")\n",
+    "memory.add(\n",
+    "    agent_id=AGENT_ID,\n",
+    "    content=\"Order 1842 shipping estimate is Friday\",\n",
+    "    event_time=datetime(2026, 8, 1, 9, tzinfo=UTC),\n",
+    "    metadata=FACT_FILTER,\n",
+    "    source=\"synthetic-order-event\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Wrap recall as an agent tool\n",
+    "\n",
+    "The class below is intentionally framework-neutral. Register `answer` as a tool in LangGraph, PydanticAI, CrewAI, or another agent framework, or expose the same memory through Lians' MCP server.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class TemporalMemoryAgent:\n",
+    "    \"\"\"Answer questions from either current or point-in-time memory.\"\"\"\n",
+    "\n",
+    "    def __init__(self, client: LocalLiansClient, agent_id: str) -> None:\n",
+    "        self.client = client\n",
+    "        self.agent_id = agent_id\n",
+    "\n",
+    "    def recall(self, query: str, as_of: datetime | None = None) -> dict[str, Any]:\n",
+    "        \"\"\"Return the full memory response, including its receipt.\"\"\"\n",
+    "        return self.client.recall(\n",
+    "            agent_id=self.agent_id,\n",
+    "            query=query,\n",
+    "            filters=FACT_FILTER,\n",
+    "            as_of=as_of,\n",
+    "            k=3,\n",
+    "        )\n",
+    "\n",
+    "    def answer(self, query: str, as_of: datetime | None = None) -> str:\n",
+    "        \"\"\"Return the best human-readable memory for an agent prompt.\"\"\"\n",
+    "        result = self.recall(query, as_of=as_of)\n",
+    "        memories = result[\"memories\"]\n",
+    "        return memories[0][\"content\"] if memories else \"No matching memory.\"\n",
+    "\n",
+    "\n",
+    "agent = TemporalMemoryAgent(memory, AGENT_ID)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Ask for the current state\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "current_answer = agent.answer(QUERY)\n",
+    "print(current_answer)\n",
+    "assert \"Monday\" in current_answer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Ask what was true before the correction\n",
+    "\n",
+    "The cutoff is Sunday at noon, three hours before the Monday estimate arrived.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "historical_answer = agent.answer(QUERY, as_of=SUNDAY_MORNING)\n",
+    "print(historical_answer)\n",
+    "assert \"Friday\" in historical_answer\n",
+    "assert \"Monday\" not in historical_answer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Verify the recall receipts\n",
+    "\n",
+    "Each recall includes the retrieval inputs and selected records in a receipt plus a SHA-256 digest. This makes it possible to detect accidental mutation between retrieval and downstream use.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def verify_receipt(result: dict[str, Any]) -> bool:\n",
+    "    \"\"\"Recompute the canonical receipt digest.\"\"\"\n",
+    "    payload = json.dumps(\n",
+    "        result[\"receipt\"],\n",
+    "        sort_keys=True,\n",
+    "        separators=(\",\", \":\"),\n",
+    "        default=str,\n",
+    "    ).encode()\n",
+    "    return hashlib.sha256(payload).hexdigest() == result[\"receipt_sha256\"]\n",
+    "\n",
+    "\n",
+    "current_result = agent.recall(QUERY)\n",
+    "historical_result = agent.recall(QUERY, as_of=SUNDAY_MORNING)\n",
+    "assert verify_receipt(current_result)\n",
+    "assert verify_receipt(historical_result)\n",
+    "print(\"PASS: current and point-in-time memory stayed separated\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Comparison\n",
+    "\n",
+    "| Approach | Current answer | Historical answer | Correction semantics | Verifiable retrieval |\n",
+    "|---|---:|---:|---:|---:|\n",
+    "| Chat history | Yes | No | Position-based | No |\n",
+    "| Basic vector store | Usually | No | Similarity-based | Usually no |\n",
+    "| Temporal memory tool | Yes | Yes | Event-time + fact identity | Yes |\n",
+    "\n",
+    "This example isolates temporal behavior by using deterministic test-grade embeddings. For production, use a semantic embedding provider and design stable entity/field metadata for each fact family. Point-in-time recall also depends on receiving trustworthy event timestamps from source systems.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cleanup and next steps\n",
+    "\n",
+    "In a real agent, keep the client open for the application lifetime and use a persistent database path. The same memory can be connected to desktop agents through MCP or called directly from Python and TypeScript SDKs.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "memory.close()\n",
+    "temp_dir.cleanup()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## References\n",
+    "\n",
+    "- [Lians source code](https://github.com/Lians-ai/Lians)\n",
+    "- [Lians documentation](https://www.lians.ai/docs)\n",
+    "- [Model Context Protocol](https://modelcontextprotocol.io/)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/all_agents_tutorials/temporal_memory_agent.ipynb
+++ b/all_agents_tutorials/temporal_memory_agent.ipynb
@@ -72,7 +72,7 @@
     "import hashlib\n",
     "import json\n",
     "import tempfile\n",
-    "from datetime import UTC, datetime\n",
+    "from datetime import datetime, timezone\n",
     "from pathlib import Path\n",
     "from typing import Any\n",
     "\n",
@@ -106,7 +106,7 @@
     "AGENT_ID = \"shipping-support-agent\"\n",
     "FACT_FILTER = {\"entity\": \"order-1842\", \"field\": \"shipping_estimate\"}\n",
     "QUERY = \"When will order 1842 ship?\"\n",
-    "SUNDAY_MORNING = datetime(2026, 8, 2, 12, tzinfo=UTC)"
+    "SUNDAY_MORNING = datetime(2026, 8, 2, 12, tzinfo=timezone.utc)"
    ]
   },
   {
@@ -127,14 +127,14 @@
     "memory.add(\n",
     "    agent_id=AGENT_ID,\n",
     "    content=\"Order 1842 shipping estimate changed to Monday\",\n",
-    "    event_time=datetime(2026, 8, 2, 15, tzinfo=UTC),\n",
+    "    event_time=datetime(2026, 8, 2, 15, tzinfo=timezone.utc),\n",
     "    metadata=FACT_FILTER,\n",
     "    source=\"synthetic-order-event\",\n",
     ")\n",
     "memory.add(\n",
     "    agent_id=AGENT_ID,\n",
     "    content=\"Order 1842 shipping estimate is Friday\",\n",
-    "    event_time=datetime(2026, 8, 1, 9, tzinfo=UTC),\n",
+    "    event_time=datetime(2026, 7, 31, 9, tzinfo=timezone.utc),\n",
     "    metadata=FACT_FILTER,\n",
     "    source=\"synthetic-order-event\",\n",
     ")"

--- a/images/temporal-memory-agent.svg
+++ b/images/temporal-memory-agent.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="460" viewBox="0 0 1200 460" role="img" aria-labelledby="title desc">
+  <title id="title">Temporal memory agent architecture</title>
+  <desc id="desc">An agent sends facts and questions to Lians local memory, which stores a timeline in SQLite and returns current or point-in-time recall with a verifiable receipt.</desc>
+  <defs>
+    <linearGradient id="memory" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#6d5dfc"/>
+      <stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#64748b"/>
+    </marker>
+    <style>
+      .label { font: 600 22px Inter, ui-sans-serif, system-ui, sans-serif; fill: #0f172a; }
+      .detail { font: 16px Inter, ui-sans-serif, system-ui, sans-serif; fill: #475569; }
+      .inverse { fill: #ffffff; }
+      .line { stroke: #64748b; stroke-width: 3; fill: none; marker-end: url(#arrow); }
+    </style>
+  </defs>
+  <rect width="1200" height="460" rx="28" fill="#f8fafc"/>
+  <text x="600" y="48" text-anchor="middle" class="label">One memory timeline, two honest answers</text>
+
+  <rect x="55" y="150" width="220" height="145" rx="22" fill="#ffffff" stroke="#cbd5e1" stroke-width="2"/>
+  <text x="165" y="205" text-anchor="middle" class="label">AI agent</text>
+  <text x="165" y="238" text-anchor="middle" class="detail">facts + questions</text>
+  <text x="165" y="265" text-anchor="middle" class="detail">any model or framework</text>
+
+  <path class="line" d="M275 222 H385"/>
+
+  <rect x="395" y="115" width="285" height="215" rx="30" fill="url(#memory)"/>
+  <g transform="translate(537 172)" fill="none" stroke="#ffffff" stroke-width="5" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M0 36 C-8 18 -26 13 -37 16 C-35 38 -18 52 0 55 C18 52 35 38 37 16 C26 13 8 18 0 36Z"/>
+    <path d="M0 36 C-3 18 4 5 15 -3 C26 12 24 31 0 55 C-24 31 -26 12 -15 -3 C-4 5 3 18 0 36Z"/>
+    <path d="M-37 39 C-53 38 -64 45 -70 55 C-51 68 -24 67 0 55 C24 67 51 68 70 55 C64 45 53 38 37 39"/>
+  </g>
+  <text x="537" y="257" text-anchor="middle" class="label inverse">Lians memory</text>
+  <text x="537" y="286" text-anchor="middle" class="detail inverse">local SDK / MCP</text>
+  <text x="537" y="312" text-anchor="middle" class="detail inverse">event-time semantics</text>
+
+  <path class="line" d="M680 222 H770"/>
+
+  <rect x="780" y="78" width="360" height="104" rx="20" fill="#ffffff" stroke="#cbd5e1" stroke-width="2"/>
+  <text x="960" y="121" text-anchor="middle" class="label">SQLite timeline</text>
+  <text x="960" y="152" text-anchor="middle" class="detail">Friday estimate → Monday correction</text>
+
+  <path class="line" d="M850 182 C825 215 825 248 850 278"/>
+  <path class="line" d="M1070 182 C1095 215 1095 248 1070 278"/>
+
+  <rect x="735" y="288" width="205" height="108" rx="20" fill="#ecfdf5" stroke="#86efac" stroke-width="2"/>
+  <text x="838" y="328" text-anchor="middle" class="label">Current</text>
+  <text x="838" y="358" text-anchor="middle" class="detail">Monday</text>
+  <text x="838" y="383" text-anchor="middle" class="detail">+ receipt</text>
+
+  <rect x="980" y="288" width="205" height="108" rx="20" fill="#eff6ff" stroke="#93c5fd" stroke-width="2"/>
+  <text x="1083" y="328" text-anchor="middle" class="label">As of Sunday</text>
+  <text x="1083" y="358" text-anchor="middle" class="detail">Friday</text>
+  <text x="1083" y="383" text-anchor="middle" class="detail">+ receipt</text>
+</svg>


### PR DESCRIPTION
## What changed

- add a notebook that builds a provider-neutral temporal-memory tool for an AI agent
- demonstrate current and point-in-time recall after a real-world fact correction
- verify retrieval receipts independently with SHA-256
- add a lotus-centered architecture diagram and register the tutorial in both README indexes

## Why

Basic chat histories and vector stores often overwrite corrections or retrieve conflicting values without time semantics. This tutorial gives readers a reproducible, no-key example where the agent answers **Monday now** but **Friday as of Sunday morning**, without leaking the later correction into the historical answer.

## Developer impact

The notebook runs locally with SQLite, does not require an LLM provider, and wraps memory behind a small class that can be registered as a tool in LangGraph, PydanticAI, CrewAI, or another framework. It also explains when to replace the deterministic tutorial embedding provider with a semantic provider.

## Validation

- executed all 23 notebook cells end to end with `nbclient`
- verified the current answer contains Monday
- verified the point-in-time answer contains Friday and excludes Monday
- recomputed and verified both recall receipt hashes
- confirmed notebook outputs are cleared
- parsed the architecture SVG as XML
- ran `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tutorial for building a temporal-memory agent with current and point-in-time recall.
  * Demonstrates storing historical information with event timestamps and shared metadata.
  * Includes durable corrections and SHA-256 receipt verification for retrieved results.
  * Adds examples, validation checks, comparison guidance, deployment considerations, and cleanup steps.

* **Documentation**
  * Added the Temporal Memory Agent to the repository’s collection of examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->