### PR TITLE
Add human-in-the-loop approval agent tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Below is a comprehensive overview of our GenAI agent implementations, organized 
 | 50 | 💼 **Business**   | [Contextual Quoting System](all_agents_tutorials/contextual_quoting_agentic_system.ipynb) | LangGraph  | Multi-agent quoting, RAG + structured data                                   |
 | 51 | 📊 **Analysis**   | [Document Intake Agent](all_agents_tutorials/document_intake_agent_langgraph.ipynb) | LangGraph  | Office docs to LLM-ready markdown, conversion as a tool call                 |
 | 52 | 🎨 **Creative**   | [Social Media Publishing Agent](all_agents_tutorials/social_media_publishing_agent_publora_langgraph.ipynb) | LangGraph  | Per-platform generation, self-review loop, publishing via Publora API        |
-| 53 | 🔍 **QA**         | [Human-in-the-Loop Approval Agent](all_agents_tutorials/human_in_the_loop_approval_agent.ipynb) | LangGraph | Risk-based approval, durable interrupts, auditable tool execution            |
+| 53 | 🔍 **QA**         | [Human-in-the-Loop Approval Agent](all_agents_tutorials/human_in_the_loop_approval_agent.ipynb) | LangGraph | Risk-based approval, in-process checkpoints, auditable tool execution        |
 
 Explore our extensive list of GenAI agent implementations, sorted by categories:
 
@@ -739,7 +739,7 @@ Explore our extensive list of GenAI agent implementations, sorted by categories:
     A safe tool-using agent that executes low-risk reads automatically but pauses consequential writes before any side effect. Reviewers can approve, reject, or replace arguments, with every transition recorded for audit.
 
     #### Implementation 🛠️
-    Combines deterministic risk and argument policies with LangGraph interrupts and checkpointed resume. The tutorial runs without an API key, uses simulated order tools, verifies that paused and rejected actions never execute, and demonstrates revalidation of reviewer-edited arguments.
+    Combines deterministic risk and argument policies with LangGraph interrupts and a notebook-local LangGraph 0.2.76 dependency. Its `InMemorySaver` supports resume only during the Python process lifetime; production restart recovery requires a persistent checkpointer. The tutorial verifies that paused and rejected actions never execute and that reviewer-edited arguments are revalidated.
 
 ### 🌟 Special Advanced Technique 🌟
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ One `npm install` adds the module's AI assistant to your Claude Code, and it gui
 
 </div>
 
-> **Recently added:** Document Intake Agent, HR AI Assistant, Art Tourguide with LightRAG, Contextual Quoting System, ML/DS Assistant | **53 tutorials** and growing
+> **Recently added:** Human-in-the-Loop Approval Agent, Document Intake Agent, HR AI Assistant, Art Tourguide with LightRAG, Contextual Quoting System | **54 tutorials** and growing
 
 ## 📫 Stay Updated!
 
@@ -209,6 +209,7 @@ Below is a comprehensive overview of our GenAI agent implementations, organized 
 | 50 | 💼 **Business**   | [Contextual Quoting System](all_agents_tutorials/contextual_quoting_agentic_system.ipynb) | LangGraph  | Multi-agent quoting, RAG + structured data                                   |
 | 51 | 📊 **Analysis**   | [Document Intake Agent](all_agents_tutorials/document_intake_agent_langgraph.ipynb) | LangGraph  | Office docs to LLM-ready markdown, conversion as a tool call                 |
 | 52 | 🎨 **Creative**   | [Social Media Publishing Agent](all_agents_tutorials/social_media_publishing_agent_publora_langgraph.ipynb) | LangGraph  | Per-platform generation, self-review loop, publishing via Publora API        |
+| 53 | 🔍 **QA**         | [Human-in-the-Loop Approval Agent](all_agents_tutorials/human_in_the_loop_approval_agent.ipynb) | LangGraph | Risk-based approval, durable interrupts, auditable tool execution            |
 
 Explore our extensive list of GenAI agent implementations, sorted by categories:
 
@@ -731,6 +732,14 @@ Explore our extensive list of GenAI agent implementations, sorted by categories:
 
     #### Implementation 🛠️
     A LangGraph workflow (fetch_connections → generate → review → publish) with a bounded revise loop: a deterministic length check plus an LLM critic send failing drafts back to the generator with targeted feedback. Publishing goes through Publora's REST API (one create-post call per platform, each with an idempotency key so a call's network retry is safe), with a dry-run mode that creates drafts so nothing goes live while experimenting.
+
+53. **[Human-in-the-Loop Approval Agent with LangGraph](https://github.com/NirDiamant/GenAI_Agents/blob/main/all_agents_tutorials/human_in_the_loop_approval_agent.ipynb)**
+
+    #### Overview 🔎
+    A safe tool-using agent that executes low-risk reads automatically but pauses consequential writes before any side effect. Reviewers can approve, reject, or replace arguments, with every transition recorded for audit.
+
+    #### Implementation 🛠️
+    Combines deterministic risk and argument policies with LangGraph interrupts and checkpointed resume. The tutorial runs without an API key, uses simulated order tools, verifies that paused and rejected actions never execute, and demonstrates revalidation of reviewer-edited arguments.
 
 ### 🌟 Special Advanced Technique 🌟
 

--- a/all_agents_tutorials/human_in_the_loop_approval_agent.ipynb
+++ b/all_agents_tutorials/human_in_the_loop_approval_agent.ipynb
@@ -1,0 +1,506 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Human-in-the-Loop Approval Agent with LangGraph\n",
+    "\n",
+    "## Overview\n",
+    "\n",
+    "Agents become risky when a model can move money, send messages, or mutate records without a deliberate checkpoint. This tutorial builds a small approval agent that classifies a proposed tool call, executes low-risk reads automatically, and pauses high-risk writes before any side effect. A reviewer can approve, reject, or replace the arguments; every transition is recorded in an audit log.\n",
+    "\n",
+    "The example uses deterministic policies and simulated tools so it is safe to run without an API key. In a production agent, an LLM or planner would propose the same structured `action`, while the policy and approval boundary remain deterministic."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Detailed Explanation\n",
+    "\n",
+    "### Why approval belongs before the tool\n",
+    "\n",
+    "A chat confirmation after a tool call is only a notification. A real approval gate must persist the proposed action, stop execution, accept a reviewer decision, validate any edited arguments, and resume from the same durable state. The policy below deliberately separates *planning* from *authorization*: a model may suggest a refund, but code decides whether a human must authorize it.\n",
+    "\n",
+    "### Agent Architecture\n",
+    "\n",
+    "![Human-in-the-Loop Approval Agent](../images/human-in-the-loop-approval-agent.svg)\n",
+    "\n",
+    "The safe boundary is the edge between the approval gate and tool execution. Rejection never crosses that boundary; modification crosses it only after the replacement arguments pass the same validation as the original proposal."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Required Packages\n",
+    "\n",
+    "### Install LangGraph\n",
+    "\n",
+    "The policy core uses only the Python standard library. LangGraph supplies durable pause-and-resume orchestration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -q \"langgraph==0.2.76\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Implementation\n",
+    "\n",
+    "### Imports and decision schema\n",
+    "\n",
+    "The reviewer response is a constrained value rather than free-form prose. `modify` requires replacement arguments, while `approve` and `reject` preserve the original action."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from copy import deepcopy\n",
+    "from dataclasses import dataclass\n",
+    "from datetime import datetime, timezone\n",
+    "from math import isfinite\n",
+    "from typing import Any, Dict, Optional\n",
+    "\n",
+    "\n",
+    "@dataclass(frozen=True)\n",
+    "class ApprovalDecision:\n",
+    "    \"\"\"A reviewer's constrained response to one paused action.\"\"\"\n",
+    "    decision: str\n",
+    "    reviewer: str\n",
+    "    reason: str = \"\"\n",
+    "    modified_args: Optional[Dict[str, Any]] = None\n",
+    "\n",
+    "    def __post_init__(self) -> None:\n",
+    "        \"\"\"Validate the decision vocabulary and modification payload.\"\"\"\n",
+    "        if self.decision not in {\"approve\", \"reject\", \"modify\"}:\n",
+    "            raise ValueError(\"decision must be approve, reject, or modify\")\n",
+    "        if self.decision == \"modify\" and self.modified_args is None:\n",
+    "            raise ValueError(\"modify requires modified_args\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define deterministic tool policies\n",
+    "\n",
+    "Only explicitly allowlisted reads are low risk. Every refund is a mutating action and requires approval, regardless of amount. Validation is code, not an LLM judgment, so invalid amounts cannot be smuggled through a reviewer edit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def validate_action(action: Dict[str, Any]) -> None:\n",
+    "    \"\"\"Reject unsupported tools and malformed tool arguments.\"\"\"\n",
+    "    tool = action.get(\"tool\")\n",
+    "    args = action.get(\"args\", {})\n",
+    "    if tool == \"lookup_order\":\n",
+    "        if not args.get(\"order_id\"):\n",
+    "            raise ValueError(\"lookup_order requires order_id\")\n",
+    "        return\n",
+    "    if tool == \"issue_refund\":\n",
+    "        if not args.get(\"order_id\"):\n",
+    "            raise ValueError(\"issue_refund requires order_id\")\n",
+    "        amount = args.get(\"amount\")\n",
+    "        if (\n",
+    "            isinstance(amount, bool)\n",
+    "            or not isinstance(amount, (int, float))\n",
+    "            or not isfinite(amount)\n",
+    "            or amount <= 0\n",
+    "        ):\n",
+    "            raise ValueError(\"amount must be a finite positive number\")\n",
+    "        return\n",
+    "    raise ValueError(f\"unsupported tool: {tool}\")\n",
+    "\n",
+    "\n",
+    "def classify_risk(action: Dict[str, Any]) -> str:\n",
+    "    \"\"\"Allowlist reads as low risk and gate every mutating tool.\"\"\"\n",
+    "    validate_action(action)\n",
+    "    if action[\"tool\"] == \"lookup_order\":\n",
+    "        return \"low\"\n",
+    "    return \"high\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create auditable request state\n",
+    "\n",
+    "Each request starts with a structured action and an append-only list of events. Timestamps are created by the workflow, while tests and downstream systems can assert on event names and reviewer identity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def audit(event: str, **details: Any) -> Dict[str, Any]:\n",
+    "    \"\"\"Create one timestamped audit event.\"\"\"\n",
+    "    return {\n",
+    "        \"event\": event,\n",
+    "        \"at\": datetime.now(timezone.utc).isoformat(),\n",
+    "        **details,\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "def new_request(tool: str, args: Dict[str, Any]) -> Dict[str, Any]:\n",
+    "    \"\"\"Validate and initialize state for a proposed tool call.\"\"\"\n",
+    "    action = {\"tool\": tool, \"args\": deepcopy(args)}\n",
+    "    validate_action(action)\n",
+    "    return {\n",
+    "        \"action\": action,\n",
+    "        \"status\": \"planned\",\n",
+    "        \"approval_request\": None,\n",
+    "        \"audit_log\": [audit(\"action_proposed\", action=deepcopy(action))],\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Simulate tools and isolate the side-effect boundary\n",
+    "\n",
+    "The tools return deterministic payloads instead of touching a real order system. Crucially, `execute_tool` is the only function that records `tool_executed`, making it easy to prove that paused and rejected requests caused no mutation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def lookup_order(order_id: str) -> Dict[str, Any]:\n",
+    "    \"\"\"Return deterministic order data for the safe tutorial.\"\"\"\n",
+    "    return {\"order_id\": order_id, \"status\": \"paid\", \"total\": 240}\n",
+    "\n",
+    "\n",
+    "def issue_refund(order_id: str, amount: float) -> Dict[str, Any]:\n",
+    "    \"\"\"Return a simulated refund receipt without moving money.\"\"\"\n",
+    "    return {\"order_id\": order_id, \"refunded\": amount, \"simulated\": True}\n",
+    "\n",
+    "\n",
+    "TOOLS = {\"lookup_order\": lookup_order, \"issue_refund\": issue_refund}\n",
+    "\n",
+    "\n",
+    "def execute_tool(state: Dict[str, Any], reviewer: Optional[str] = None) -> Dict[str, Any]:\n",
+    "    \"\"\"Execute a validated tool and append its auditable receipt.\"\"\"\n",
+    "    updated = deepcopy(state)\n",
+    "    action = updated[\"action\"]\n",
+    "    validate_action(action)\n",
+    "    updated[\"tool_result\"] = TOOLS[action[\"tool\"]](**action[\"args\"])\n",
+    "    updated[\"status\"] = \"completed\"\n",
+    "    updated[\"approval_request\"] = None\n",
+    "    updated[\"audit_log\"].append(\n",
+    "        audit(\"tool_executed\", tool=action[\"tool\"], reviewer=reviewer)\n",
+    "    )\n",
+    "    return updated"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Pause at the approval gate\n",
+    "\n",
+    "Low-risk actions cross the boundary immediately. A high-risk action returns serializable approval context and stops before calling a tool."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def run_until_pause(state: Dict[str, Any]) -> Dict[str, Any]:\n",
+    "    \"\"\"Execute allowlisted reads or return a serializable approval request.\"\"\"\n",
+    "    updated = deepcopy(state)\n",
+    "    risk = classify_risk(updated[\"action\"])\n",
+    "    updated[\"audit_log\"].append(audit(\"risk_classified\", risk=risk))\n",
+    "    if risk == \"low\":\n",
+    "        return execute_tool(updated)\n",
+    "\n",
+    "    updated[\"status\"] = \"awaiting_approval\"\n",
+    "    updated[\"approval_request\"] = {\n",
+    "        \"risk\": risk,\n",
+    "        \"action\": deepcopy(updated[\"action\"]),\n",
+    "        \"allowed_decisions\": [\"approve\", \"reject\", \"modify\"],\n",
+    "    }\n",
+    "    updated[\"audit_log\"].append(audit(\"approval_requested\", risk=risk))\n",
+    "    return updated"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Resume with approve, reject, or modify\n",
+    "\n",
+    "A rejected request terminates without a tool result. Approval executes the persisted proposal. Modification replaces only the arguments, revalidates them, and records both the decision and the reviewer before execution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def resume_with_decision(\n",
+    "    state: Dict[str, Any], decision: ApprovalDecision\n",
+    ") -> Dict[str, Any]:\n",
+    "    \"\"\"Apply a review decision and execute only authorized actions.\"\"\"\n",
+    "    if state.get(\"status\") != \"awaiting_approval\":\n",
+    "        raise ValueError(\"request is not awaiting approval\")\n",
+    "\n",
+    "    updated = deepcopy(state)\n",
+    "    if decision.decision == \"reject\":\n",
+    "        updated[\"status\"] = \"rejected\"\n",
+    "        updated[\"approval_request\"] = None\n",
+    "        updated[\"audit_log\"].append(\n",
+    "            audit(\"action_rejected\", reviewer=decision.reviewer, reason=decision.reason)\n",
+    "        )\n",
+    "        return updated\n",
+    "\n",
+    "    if decision.decision == \"modify\":\n",
+    "        before = deepcopy(updated[\"action\"][\"args\"])\n",
+    "        candidate = deepcopy(updated[\"action\"])\n",
+    "        candidate[\"args\"] = deepcopy(decision.modified_args)\n",
+    "        validate_action(candidate)\n",
+    "        updated[\"action\"] = candidate\n",
+    "        updated[\"audit_log\"].append(\n",
+    "            audit(\n",
+    "                \"action_modified\",\n",
+    "                reviewer=decision.reviewer,\n",
+    "                before=before,\n",
+    "                after=deepcopy(candidate[\"args\"]),\n",
+    "            )\n",
+    "        )\n",
+    "\n",
+    "    updated[\"audit_log\"].append(\n",
+    "        audit(\"action_authorized\", reviewer=decision.reviewer, decision=decision.decision)\n",
+    "    )\n",
+    "    return execute_tool(updated, reviewer=decision.reviewer)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Wrap the policy with LangGraph interrupt and resume\n",
+    "\n",
+    "`interrupt` persists the approval payload through the checkpointer. The caller receives `__interrupt__`, obtains a reviewer decision, and resumes the same thread with `Command(resume=...)`. In production, replace `InMemorySaver` with a durable database-backed checkpointer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "requires-langgraph"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from typing import TypedDict\n",
+    "\n",
+    "from langgraph.checkpoint.memory import InMemorySaver\n",
+    "from langgraph.graph import END, START, StateGraph\n",
+    "from langgraph.types import Command, interrupt\n",
+    "\n",
+    "\n",
+    "class GraphState(TypedDict, total=False):\n",
+    "    \"\"\"Serializable state persisted around the approval interrupt.\"\"\"\n",
+    "    action: Dict[str, Any]\n",
+    "    status: str\n",
+    "    approval_request: Optional[Dict[str, Any]]\n",
+    "    audit_log: list\n",
+    "    tool_result: Dict[str, Any]\n",
+    "\n",
+    "\n",
+    "def approval_node(state: GraphState) -> GraphState:\n",
+    "    \"\"\"Pause high-risk actions and resume with a structured decision.\"\"\"\n",
+    "    paused_or_complete = run_until_pause(dict(state))\n",
+    "    if paused_or_complete[\"status\"] != \"awaiting_approval\":\n",
+    "        return paused_or_complete\n",
+    "    raw_decision = interrupt(paused_or_complete[\"approval_request\"])\n",
+    "    return resume_with_decision(\n",
+    "        paused_or_complete, ApprovalDecision(**raw_decision)\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "builder = StateGraph(GraphState)\n",
+    "builder.add_node(\"approval_gate\", approval_node)\n",
+    "builder.add_edge(START, \"approval_gate\")\n",
+    "builder.add_edge(\"approval_gate\", END)\n",
+    "approval_graph = builder.compile(checkpointer=InMemorySaver())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Usage Example\n",
+    "\n",
+    "### Low-risk reads complete immediately\n",
+    "\n",
+    "No reviewer is needed for a read-only lookup."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lookup = run_until_pause(new_request(\"lookup_order\", {\"order_id\": \"A-100\"}))\n",
+    "print(lookup[\"status\"], lookup[\"tool_result\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### High-risk refunds pause and resume\n",
+    "\n",
+    "The first invocation stops with approval context and no `tool_result`. The second resumes the same thread with a reviewer-approved lower amount."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "requires-langgraph"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "config = {\"configurable\": {\"thread_id\": \"refund-demo-1\"}}\n",
+    "request = new_request(\n",
+    "    \"issue_refund\", {\"order_id\": \"A-100\", \"amount\": 240}\n",
+    ")\n",
+    "updates = list(\n",
+    "    approval_graph.stream(request, config=config, stream_mode=\"updates\")\n",
+    ")\n",
+    "approval_request = next(\n",
+    "    update[\"__interrupt__\"][0].value\n",
+    "    for update in updates\n",
+    "    if \"__interrupt__\" in update\n",
+    ")\n",
+    "paused = approval_graph.get_state(config).values\n",
+    "print(\"Paused:\", approval_request)\n",
+    "\n",
+    "completed = approval_graph.invoke(\n",
+    "    Command(\n",
+    "        resume={\n",
+    "            \"decision\": \"modify\",\n",
+    "            \"reviewer\": \"ops@example.com\",\n",
+    "            \"reason\": \"Approve within discretionary limit\",\n",
+    "            \"modified_args\": {\"order_id\": \"A-100\", \"amount\": 80},\n",
+    "        }\n",
+    "    ),\n",
+    "    config=config,\n",
+    ")\n",
+    "print(\"Completed:\", completed[\"tool_result\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Verify the safety invariants\n",
+    "\n",
+    "These assertions are executable documentation: the graph must pause before a side effect and must use the reviewer's validated amount after resuming."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "requires-langgraph"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "assert \"tool_result\" not in paused\n",
+    "assert completed[\"status\"] == \"completed\"\n",
+    "assert completed[\"tool_result\"][\"refunded\"] == 80\n",
+    "assert completed[\"tool_result\"][\"simulated\"] is True\n",
+    "print(\"Safety invariants verified\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Comparison\n",
+    "\n",
+    "| Pattern | Stops before side effect | Durable resume | Reviewer can edit arguments | Auditability |\n",
+    "|---|---:|---:|---:|---:|\n",
+    "| Ask for confirmation in the prompt | No guarantee | No | Unstructured | Low |\n",
+    "| Approve every tool call | Yes | Depends on runtime | Usually | High, but noisy |\n",
+    "| Risk-based interrupt (this tutorial) | Yes | Yes, with a checkpointer | Yes, then revalidated | High |\n",
+    "| Fully autonomous tools | No | Not applicable | No | Depends on tracing |\n",
+    "\n",
+    "Risk-based approval preserves autonomy for harmless reads while reserving human attention for consequential actions. It is more code than a prompt-level confirmation because it provides a real authorization boundary rather than a conversational convention."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Additional Considerations\n",
+    "\n",
+    "- **Use durable checkpoints.** `InMemorySaver` is appropriate for a tutorial, not a service restart. Use a supported database checkpointer and encrypt sensitive state.\n",
+    "- **Bind identity server-side.** Do not trust a reviewer email supplied by the browser. Resolve the authenticated principal in the approval API and enforce role or amount limits there.\n",
+    "- **Make approvals expire.** Revalidate inventory, balances, policy versions, and target records when a stale approval resumes.\n",
+    "- **Protect against double execution.** Give mutation tools an idempotency key tied to the request, and persist the execution receipt.\n",
+    "- **Show the exact effect.** Approval UI should display tool name, normalized arguments, policy reason, and a diff when arguments were modified.\n",
+    "- **Keep policy deterministic.** An LLM can explain risk, but hard authorization limits should remain testable code.\n",
+    "- **Escalate unknown tools.** This tutorial rejects them. Production systems should default-deny missing policy entries rather than silently treating them as low risk."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## References\n",
+    "\n",
+    "- [LangGraph interrupts](https://docs.langchain.com/oss/python/langgraph/interrupts)\n",
+    "- [LangGraph persistence](https://docs.langchain.com/oss/python/langgraph/persistence)\n",
+    "- [OWASP Agentic AI Threats and Mitigations](https://genai.owasp.org/resource/agentic-ai-threats-and-mitigations/)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/all_agents_tutorials/human_in_the_loop_approval_agent.ipynb
+++ b/all_agents_tutorials/human_in_the_loop_approval_agent.ipynb
@@ -21,7 +21,7 @@
     "\n",
     "### Why approval belongs before the tool\n",
     "\n",
-    "A chat confirmation after a tool call is only a notification. A real approval gate must persist the proposed action, stop execution, accept a reviewer decision, validate any edited arguments, and resume from the same durable state. The policy below deliberately separates *planning* from *authorization*: a model may suggest a refund, but code decides whether a human must authorize it.\n",
+    "A chat confirmation after a tool call is only a notification. A real approval gate must checkpoint the proposed action, stop execution, accept a reviewer decision, validate any edited arguments, and resume from the same state. Restart recovery additionally requires a persistent checkpointer. The policy below deliberately separates *planning* from *authorization*: a model may suggest a refund, but code decides whether a human must authorize it.\n",
     "\n",
     "### Agent Architecture\n",
     "\n",
@@ -38,7 +38,7 @@
     "\n",
     "### Install LangGraph\n",
     "\n",
-    "The policy core uses only the Python standard library. LangGraph supplies durable pause-and-resume orchestration."
+    "The policy core uses only the Python standard library. This notebook pins LangGraph 0.2.76 for its interrupt/resume API; the repository-wide requirements retain an older version for existing tutorials. Run the notebook in its own environment. Focused graph tests explicitly skip unless this exact notebook version is installed."
    ]
   },
   {
@@ -109,11 +109,19 @@
     "    \"\"\"Reject unsupported tools and malformed tool arguments.\"\"\"\n",
     "    tool = action.get(\"tool\")\n",
     "    args = action.get(\"args\", {})\n",
+    "    if not isinstance(args, dict):\n",
+    "        raise ValueError(\"action args must be a dictionary\")\n",
     "    if tool == \"lookup_order\":\n",
+    "        unexpected = set(args) - {\"order_id\"}\n",
+    "        if unexpected:\n",
+    "            raise ValueError(f\"lookup_order received unexpected arguments: {sorted(unexpected)}\")\n",
     "        if not args.get(\"order_id\"):\n",
     "            raise ValueError(\"lookup_order requires order_id\")\n",
     "        return\n",
     "    if tool == \"issue_refund\":\n",
+    "        unexpected = set(args) - {\"order_id\", \"amount\"}\n",
+    "        if unexpected:\n",
+    "            raise ValueError(f\"issue_refund received unexpected arguments: {sorted(unexpected)}\")\n",
     "        if not args.get(\"order_id\"):\n",
     "            raise ValueError(\"issue_refund requires order_id\")\n",
     "        amount = args.get(\"amount\")\n",
@@ -178,7 +186,7 @@
    "source": [
     "### Simulate tools and isolate the side-effect boundary\n",
     "\n",
-    "The tools return deterministic payloads instead of touching a real order system. Crucially, `execute_tool` is the only function that records `tool_executed`, making it easy to prove that paused and rejected requests caused no mutation."
+    "The tools return deterministic payloads instead of touching a real order system. Crucially, `execute_tool` is the only dispatcher and independently refuses high-risk actions unless the state was authorized by a reviewer decision. This makes the approval invariant hold even when a caller bypasses the normal workflow."
    ]
   },
   {
@@ -204,7 +212,9 @@
     "    \"\"\"Execute a validated tool and append its auditable receipt.\"\"\"\n",
     "    updated = deepcopy(state)\n",
     "    action = updated[\"action\"]\n",
-    "    validate_action(action)\n",
+    "    risk = classify_risk(action)\n",
+    "    if risk == \"high\" and updated.get(\"status\") != \"authorized\":\n",
+    "        raise PermissionError(\"high-risk actions require authorization\")\n",
     "    updated[\"tool_result\"] = TOOLS[action[\"tool\"]](**action[\"args\"])\n",
     "    updated[\"status\"] = \"completed\"\n",
     "    updated[\"approval_request\"] = None\n",
@@ -296,6 +306,7 @@
     "    updated[\"audit_log\"].append(\n",
     "        audit(\"action_authorized\", reviewer=decision.reviewer, decision=decision.decision)\n",
     "    )\n",
+    "    updated[\"status\"] = \"authorized\"\n",
     "    return execute_tool(updated, reviewer=decision.reviewer)"
    ]
   },
@@ -305,7 +316,7 @@
    "source": [
     "### Wrap the policy with LangGraph interrupt and resume\n",
     "\n",
-    "`interrupt` persists the approval payload through the checkpointer. The caller receives `__interrupt__`, obtains a reviewer decision, and resumes the same thread with `Command(resume=...)`. In production, replace `InMemorySaver` with a durable database-backed checkpointer."
+    "The policy node first returns `awaiting_approval`, so that state and its audit event are committed before the next node calls `interrupt`. The caller receives `__interrupt__`, obtains a reviewer decision, and resumes the same thread with `Command(resume=...)`. `InMemorySaver` supports this only while the Python process remains alive; restart recovery requires a persistent database-backed checkpointer."
    ]
   },
   {
@@ -334,20 +345,31 @@
     "    tool_result: Dict[str, Any]\n",
     "\n",
     "\n",
+    "def policy_node(state: GraphState) -> GraphState:\n",
+    "    \"\"\"Commit either a completed read or an awaiting-approval state.\"\"\"\n",
+    "    return run_until_pause(dict(state))\n",
+    "\n",
+    "\n",
+    "def route_after_policy(state: GraphState) -> str:\n",
+    "    \"\"\"Route only persisted high-risk requests to human review.\"\"\"\n",
+    "    if state[\"status\"] == \"awaiting_approval\":\n",
+    "        return \"approval_gate\"\n",
+    "    return END\n",
+    "\n",
+    "\n",
     "def approval_node(state: GraphState) -> GraphState:\n",
-    "    \"\"\"Pause high-risk actions and resume with a structured decision.\"\"\"\n",
-    "    paused_or_complete = run_until_pause(dict(state))\n",
-    "    if paused_or_complete[\"status\"] != \"awaiting_approval\":\n",
-    "        return paused_or_complete\n",
-    "    raw_decision = interrupt(paused_or_complete[\"approval_request\"])\n",
-    "    return resume_with_decision(\n",
-    "        paused_or_complete, ApprovalDecision(**raw_decision)\n",
-    "    )\n",
+    "    \"\"\"Interrupt a persisted request and apply its structured decision.\"\"\"\n",
+    "    raw_decision = interrupt(state[\"approval_request\"])\n",
+    "    return resume_with_decision(dict(state), ApprovalDecision(**raw_decision))\n",
     "\n",
     "\n",
     "builder = StateGraph(GraphState)\n",
+    "builder.add_node(\"policy\", policy_node)\n",
     "builder.add_node(\"approval_gate\", approval_node)\n",
-    "builder.add_edge(START, \"approval_gate\")\n",
+    "builder.add_edge(START, \"policy\")\n",
+    "builder.add_conditional_edges(\n",
+    "    \"policy\", route_after_policy, {\"approval_gate\": \"approval_gate\", END: END}\n",
+    ")\n",
     "builder.add_edge(\"approval_gate\", END)\n",
     "approval_graph = builder.compile(checkpointer=InMemorySaver())"
    ]
@@ -440,6 +462,9 @@
    },
    "outputs": [],
    "source": [
+    "assert paused[\"status\"] == \"awaiting_approval\"\n",
+    "assert paused[\"approval_request\"] == approval_request\n",
+    "assert paused[\"audit_log\"][-1][\"event\"] == \"approval_requested\"\n",
     "assert \"tool_result\" not in paused\n",
     "assert completed[\"status\"] == \"completed\"\n",
     "assert completed[\"tool_result\"][\"refunded\"] == 80\n",
@@ -453,11 +478,11 @@
    "source": [
     "## Comparison\n",
     "\n",
-    "| Pattern | Stops before side effect | Durable resume | Reviewer can edit arguments | Auditability |\n",
+    "| Pattern | Stops before side effect | Restart recovery | Reviewer can edit arguments | Auditability |\n",
     "|---|---:|---:|---:|---:|\n",
     "| Ask for confirmation in the prompt | No guarantee | No | Unstructured | Low |\n",
     "| Approve every tool call | Yes | Depends on runtime | Usually | High, but noisy |\n",
-    "| Risk-based interrupt (this tutorial) | Yes | Yes, with a checkpointer | Yes, then revalidated | High |\n",
+    "| Risk-based interrupt (this tutorial) | Yes | Process lifetime here; persistent checkpointer required | Yes, then revalidated | High |\n",
     "| Fully autonomous tools | No | Not applicable | No | Depends on tracing |\n",
     "\n",
     "Risk-based approval preserves autonomy for harmless reads while reserving human attention for consequential actions. It is more code than a prompt-level confirmation because it provides a real authorization boundary rather than a conversational convention."

--- a/images/human-in-the-loop-approval-agent.svg
+++ b/images/human-in-the-loop-approval-agent.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="500" viewBox="0 0 1100 500" role="img" aria-labelledby="title desc">
+  <title id="title">Human-in-the-loop approval agent architecture</title>
+  <desc id="desc">A proposed tool call passes through validation and risk policy. Low-risk calls execute, while high-risk calls pause for approval, rejection, or modified arguments.</desc>
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto"><path d="M0,0 L0,6 L9,3 z" fill="#475569"/></marker>
+    <style>
+      .box{rx:18;stroke-width:2}.label{font:600 20px system-ui,sans-serif;fill:#0f172a}.small{font:15px system-ui,sans-serif;fill:#334155}.edge{stroke:#475569;stroke-width:3;fill:none;marker-end:url(#arrow)}
+    </style>
+  </defs>
+  <rect width="1100" height="500" rx="28" fill="#f8fafc"/>
+  <text x="550" y="50" text-anchor="middle" class="label" font-size="26">Human-in-the-Loop Approval Boundary</text>
+  <rect class="box" x="45" y="185" width="190" height="110" fill="#dbeafe" stroke="#2563eb"/>
+  <text x="140" y="225" text-anchor="middle" class="label">Proposed action</text><text x="140" y="255" text-anchor="middle" class="small">tool + arguments</text>
+  <rect class="box" x="295" y="185" width="190" height="110" fill="#ede9fe" stroke="#7c3aed"/>
+  <text x="390" y="225" text-anchor="middle" class="label">Policy gate</text><text x="390" y="255" text-anchor="middle" class="small">validate + classify</text>
+  <rect class="box" x="555" y="70" width="220" height="110" fill="#dcfce7" stroke="#16a34a"/>
+  <text x="665" y="112" text-anchor="middle" class="label">Low risk</text><text x="665" y="142" text-anchor="middle" class="small">continue automatically</text>
+  <rect class="box" x="555" y="310" width="220" height="130" fill="#fef3c7" stroke="#d97706"/>
+  <text x="665" y="350" text-anchor="middle" class="label">Human review</text><text x="665" y="380" text-anchor="middle" class="small">approve · reject · modify</text><text x="665" y="408" text-anchor="middle" class="small">durable interrupt</text>
+  <rect class="box" x="850" y="185" width="205" height="110" fill="#cffafe" stroke="#0891b2"/>
+  <text x="952" y="225" text-anchor="middle" class="label">Simulated tool</text><text x="952" y="255" text-anchor="middle" class="small">side effect + receipt</text>
+  <path class="edge" d="M235 240 H295"/><path class="edge" d="M485 220 C520 190 520 125 555 125"/><path class="edge" d="M775 125 C825 125 810 220 850 230"/>
+  <path class="edge" d="M485 260 C520 290 520 375 555 375"/><path class="edge" d="M775 375 C825 375 810 270 850 250"/>
+  <text x="510" y="145" class="small">low</text><text x="505" y="346" class="small">high</text>
+  <path d="M775 405 H835" stroke="#dc2626" stroke-width="3"/><text x="805" y="430" text-anchor="middle" class="small" fill="#dc2626">reject → stop</text>
+  <rect x="300" y="462" width="500" height="25" rx="12" fill="#e2e8f0"/><text x="550" y="480" text-anchor="middle" class="small">Every proposal, decision, edit, and execution is appended to the audit log</text>
+</svg>

--- a/images/human-in-the-loop-approval-agent.svg
+++ b/images/human-in-the-loop-approval-agent.svg
@@ -16,7 +16,7 @@
   <rect class="box" x="555" y="70" width="220" height="110" fill="#dcfce7" stroke="#16a34a"/>
   <text x="665" y="112" text-anchor="middle" class="label">Low risk</text><text x="665" y="142" text-anchor="middle" class="small">continue automatically</text>
   <rect class="box" x="555" y="310" width="220" height="130" fill="#fef3c7" stroke="#d97706"/>
-  <text x="665" y="350" text-anchor="middle" class="label">Human review</text><text x="665" y="380" text-anchor="middle" class="small">approve · reject · modify</text><text x="665" y="408" text-anchor="middle" class="small">durable interrupt</text>
+  <text x="665" y="350" text-anchor="middle" class="label">Human review</text><text x="665" y="380" text-anchor="middle" class="small">approve · reject · modify</text><text x="665" y="408" text-anchor="middle" class="small">in-process checkpoint</text>
   <rect class="box" x="850" y="185" width="205" height="110" fill="#cffafe" stroke="#0891b2"/>
   <text x="952" y="225" text-anchor="middle" class="label">Simulated tool</text><text x="952" y="255" text-anchor="middle" class="small">side effect + receipt</text>
   <path class="edge" d="M235 240 H295"/><path class="edge" d="M485 220 C520 190 520 125 555 125"/><path class="edge" d="M775 125 C825 125 810 220 850 230"/>

--- a/tests/test_hitl_approval_agent.py
+++ b/tests/test_hitl_approval_agent.py
@@ -1,0 +1,222 @@
+import json
+import sys
+import types
+import unittest
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+NOTEBOOK = REPO_ROOT / "all_agents_tutorials" / "human_in_the_loop_approval_agent.ipynb"
+
+
+def has_compatible_langgraph() -> bool:
+    """Require the interrupt API version pinned by the tutorial notebook."""
+    try:
+        release = tuple(int(part) for part in version("langgraph").split(".")[:3])
+    except (PackageNotFoundError, ValueError):
+        return False
+    return release >= (0, 2, 76)
+
+
+def load_notebook_namespace(include_langgraph: bool = False) -> dict:
+    notebook = json.loads(NOTEBOOK.read_text(encoding="utf-8"))
+    module_name = "notebook_under_test_full" if include_langgraph else "notebook_under_test_core"
+    module = types.ModuleType(module_name)
+    sys.modules[module_name] = module
+    namespace = module.__dict__
+    for cell in notebook["cells"]:
+        if cell.get("cell_type") != "code":
+            continue
+        if (
+            not include_langgraph
+            and "requires-langgraph" in cell.get("metadata", {}).get("tags", [])
+        ):
+            continue
+        source = "".join(cell.get("source", []))
+        if source.lstrip().startswith(("!", "%")) or "IPython.display" in source:
+            continue
+        exec(compile(source, str(NOTEBOOK), "exec"), namespace)
+    return namespace
+
+
+class HumanApprovalAgentTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.ns = load_notebook_namespace()
+
+    def test_low_risk_action_executes_without_an_approval_request(self):
+        state = self.ns["run_until_pause"](
+            self.ns["new_request"]("lookup_order", {"order_id": "A-100"})
+        )
+
+        self.assertEqual(state["status"], "completed")
+        self.assertIsNone(state["approval_request"])
+        self.assertEqual(state["audit_log"][-1]["event"], "tool_executed")
+
+    def test_high_risk_action_pauses_before_any_side_effect(self):
+        state = self.ns["run_until_pause"](
+            self.ns["new_request"](
+                "issue_refund", {"order_id": "A-100", "amount": 240}
+            )
+        )
+
+        self.assertEqual(state["status"], "awaiting_approval")
+        self.assertEqual(state["approval_request"]["risk"], "high")
+        self.assertNotIn("tool_result", state)
+        self.assertFalse(any(e["event"] == "tool_executed" for e in state["audit_log"]))
+
+    def test_small_mutating_refund_also_pauses_before_side_effect(self):
+        state = self.ns["run_until_pause"](
+            self.ns["new_request"](
+                "issue_refund", {"order_id": "A-100", "amount": 80}
+            )
+        )
+
+        self.assertEqual(state["status"], "awaiting_approval")
+        self.assertNotIn("tool_result", state)
+
+    def test_approve_resumes_and_executes_the_original_action(self):
+        paused = self.ns["run_until_pause"](
+            self.ns["new_request"](
+                "issue_refund", {"order_id": "A-100", "amount": 240}
+            )
+        )
+        completed = self.ns["resume_with_decision"](
+            paused, self.ns["ApprovalDecision"]("approve", reviewer="ops@example.com")
+        )
+
+        self.assertEqual(completed["status"], "completed")
+        self.assertEqual(completed["tool_result"]["refunded"], 240)
+        self.assertEqual(completed["audit_log"][-1]["reviewer"], "ops@example.com")
+
+    def test_reject_finishes_without_executing_the_action(self):
+        paused = self.ns["run_until_pause"](
+            self.ns["new_request"](
+                "issue_refund", {"order_id": "A-100", "amount": 240}
+            )
+        )
+        rejected = self.ns["resume_with_decision"](
+            paused,
+            self.ns["ApprovalDecision"](
+                "reject", reviewer="ops@example.com", reason="Policy exception required"
+            ),
+        )
+
+        self.assertEqual(rejected["status"], "rejected")
+        self.assertNotIn("tool_result", rejected)
+        self.assertFalse(any(e["event"] == "tool_executed" for e in rejected["audit_log"]))
+
+    def test_modify_revalidates_and_executes_reviewer_arguments(self):
+        paused = self.ns["run_until_pause"](
+            self.ns["new_request"](
+                "issue_refund", {"order_id": "A-100", "amount": 240}
+            )
+        )
+        modified = self.ns["resume_with_decision"](
+            paused,
+            self.ns["ApprovalDecision"](
+                "modify",
+                reviewer="ops@example.com",
+                modified_args={"order_id": "A-100", "amount": 80},
+            ),
+        )
+
+        self.assertEqual(modified["status"], "completed")
+        self.assertEqual(modified["tool_result"]["refunded"], 80)
+        self.assertEqual(modified["action"]["args"]["amount"], 80)
+        modification = next(
+            event for event in modified["audit_log"]
+            if event["event"] == "action_modified"
+        )
+        self.assertEqual(modification["before"]["amount"], 240)
+        self.assertEqual(modification["after"]["amount"], 80)
+
+    def test_invalid_modified_arguments_are_blocked(self):
+        paused = self.ns["run_until_pause"](
+            self.ns["new_request"](
+                "issue_refund", {"order_id": "A-100", "amount": 240}
+            )
+        )
+
+        with self.assertRaisesRegex(ValueError, "amount"):
+            self.ns["resume_with_decision"](
+                paused,
+                self.ns["ApprovalDecision"](
+                    "modify",
+                    reviewer="ops@example.com",
+                    modified_args={"order_id": "A-100", "amount": -5},
+                ),
+            )
+
+    def test_boolean_and_non_finite_refund_amounts_are_rejected(self):
+        for amount in (True, float("nan"), float("inf")):
+            with self.subTest(amount=amount):
+                with self.assertRaisesRegex(ValueError, "finite positive number"):
+                    self.ns["new_request"](
+                        "issue_refund", {"order_id": "A-100", "amount": amount}
+                    )
+
+
+@unittest.skipUnless(
+    has_compatible_langgraph(),
+    "requires langgraph>=0.2.76 for interrupt/resume integration tests",
+)
+class LangGraphApprovalTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.ns = load_notebook_namespace(include_langgraph=True)
+
+    def pause(self, thread_id: str, amount: int = 240):
+        config = {"configurable": {"thread_id": thread_id}}
+        request = self.ns["new_request"](
+            "issue_refund", {"order_id": "A-100", "amount": amount}
+        )
+        updates = list(
+            self.ns["approval_graph"].stream(
+                request, config=config, stream_mode="updates"
+            )
+        )
+        interrupt = next(update["__interrupt__"][0] for update in updates if "__interrupt__" in update)
+        return config, interrupt
+
+    def test_graph_interrupts_before_refund_execution(self):
+        config, interrupt = self.pause("graph-pause")
+        snapshot = self.ns["approval_graph"].get_state(config).values
+
+        self.assertEqual(interrupt.value["action"]["tool"], "issue_refund")
+        self.assertNotIn("tool_result", snapshot)
+
+    def test_graph_resumes_approve_reject_and_modify_decisions(self):
+        decisions = [
+            ("approve", {}, "completed", 240),
+            ("reject", {"reason": "outside policy"}, "rejected", None),
+            (
+                "modify",
+                {"modified_args": {"order_id": "A-100", "amount": 80}},
+                "completed",
+                80,
+            ),
+        ]
+        for index, (decision, extra, status, refunded) in enumerate(decisions):
+            with self.subTest(decision=decision):
+                config, _ = self.pause(f"graph-resume-{index}")
+                result = self.ns["approval_graph"].invoke(
+                    self.ns["Command"](
+                        resume={
+                            "decision": decision,
+                            "reviewer": "ops@example.com",
+                            **extra,
+                        }
+                    ),
+                    config=config,
+                )
+                self.assertEqual(result["status"], status)
+                if refunded is None:
+                    self.assertNotIn("tool_result", result)
+                else:
+                    self.assertEqual(result["tool_result"]["refunded"], refunded)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hitl_approval_agent.py
+++ b/tests/test_hitl_approval_agent.py
@@ -8,15 +8,16 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 NOTEBOOK = REPO_ROOT / "all_agents_tutorials" / "human_in_the_loop_approval_agent.ipynb"
+TUTORIAL_LANGGRAPH_VERSION = "0.2.76"
 
 
 def has_compatible_langgraph() -> bool:
-    """Require the interrupt API version pinned by the tutorial notebook."""
+    """Run integration tests only with the version pinned by the notebook."""
     try:
-        release = tuple(int(part) for part in version("langgraph").split(".")[:3])
-    except (PackageNotFoundError, ValueError):
+        installed_version = version("langgraph")
+    except PackageNotFoundError:
         return False
-    return release >= (0, 2, 76)
+    return installed_version == TUTORIAL_LANGGRAPH_VERSION
 
 
 def load_notebook_namespace(include_langgraph: bool = False) -> dict:
@@ -75,6 +76,14 @@ class HumanApprovalAgentTests(unittest.TestCase):
 
         self.assertEqual(state["status"], "awaiting_approval")
         self.assertNotIn("tool_result", state)
+
+    def test_planned_refund_cannot_call_tool_dispatcher_directly(self):
+        planned = self.ns["new_request"](
+            "issue_refund", {"order_id": "A-100", "amount": 80}
+        )
+
+        with self.assertRaises(PermissionError):
+            self.ns["execute_tool"](planned)
 
     def test_approve_resumes_and_executes_the_original_action(self):
         paused = self.ns["run_until_pause"](
@@ -149,6 +158,40 @@ class HumanApprovalAgentTests(unittest.TestCase):
                 ),
             )
 
+    def test_unexpected_tool_arguments_are_rejected(self):
+        actions = [
+            ("lookup_order", {"order_id": "A-100", "debug": True}),
+            (
+                "issue_refund",
+                {"order_id": "A-100", "amount": 80, "currency": "USD"},
+            ),
+        ]
+        for tool, args in actions:
+            with self.subTest(tool=tool):
+                with self.assertRaisesRegex(ValueError, "unexpected arguments"):
+                    self.ns["new_request"](tool, args)
+
+    def test_unexpected_modified_arguments_are_blocked(self):
+        paused = self.ns["run_until_pause"](
+            self.ns["new_request"](
+                "issue_refund", {"order_id": "A-100", "amount": 240}
+            )
+        )
+
+        with self.assertRaisesRegex(ValueError, "unexpected arguments"):
+            self.ns["resume_with_decision"](
+                paused,
+                self.ns["ApprovalDecision"](
+                    "modify",
+                    reviewer="ops@example.com",
+                    modified_args={
+                        "order_id": "A-100",
+                        "amount": 80,
+                        "currency": "USD",
+                    },
+                ),
+            )
+
     def test_boolean_and_non_finite_refund_amounts_are_rejected(self):
         for amount in (True, float("nan"), float("inf")):
             with self.subTest(amount=amount):
@@ -160,7 +203,7 @@ class HumanApprovalAgentTests(unittest.TestCase):
 
 @unittest.skipUnless(
     has_compatible_langgraph(),
-    "requires langgraph>=0.2.76 for interrupt/resume integration tests",
+    "requires the notebook-pinned langgraph==0.2.76; other versions skip explicitly",
 )
 class LangGraphApprovalTests(unittest.TestCase):
     @classmethod
@@ -185,6 +228,9 @@ class LangGraphApprovalTests(unittest.TestCase):
         snapshot = self.ns["approval_graph"].get_state(config).values
 
         self.assertEqual(interrupt.value["action"]["tool"], "issue_refund")
+        self.assertEqual(snapshot["status"], "awaiting_approval")
+        self.assertEqual(snapshot["approval_request"], interrupt.value)
+        self.assertEqual(snapshot["audit_log"][-1]["event"], "approval_requested")
         self.assertNotIn("tool_result", snapshot)
 
     def test_graph_resumes_approve_reject_and_modify_decisions(self):


### PR DESCRIPTION
## Summary\n\n- add a Human-in-the-Loop Approval Agent tutorial following the repository notebook structure\n- demonstrate deterministic risk policy, LangGraph interrupts, persisted pending state, and approve/reject/modify decisions\n- enforce authorization again at the tool dispatcher and reject unsupported arguments\n- add an architecture diagram, README registration, and focused core plus graph-level tests\n\n## Why\n\nTool-using agents need an authorization boundary before consequential side effects. This tutorial shows that boundary explicitly: allowlisted reads may proceed, every mutation pauses, edited arguments are revalidated, and proposals, decisions, edits, and execution receipts are auditable.\n\n## Validation\n\n- Python 3.9 default environment: 11 core tests passed; 2 graph integration tests explicitly skipped because the notebook-pinned LangGraph version was not installed\n- Python 3.9 with langgraph==0.2.76: all 13 tests passed, including persisted pending state and approve/reject/modify resume paths\n- executed all Python notebook cells end to end\n- validated notebook structure, cleared outputs, Python syntax, and function/class docstrings\n- parsed and rendered the architecture SVG\n- git diff --check\n\n## Risks / known gaps\n\n- InMemorySaver supports resume only during the Python process lifetime; production restart recovery requires a persistent database-backed checkpointer\n- the repository-wide requirements pin an older LangGraph for existing tutorials, so this notebook documents an isolated 0.2.76 environment and its graph tests require that exact version\n- another open tutorial PR may require the README number to be rebased before merge\n\nThis is a self-contained contribution and does not close an existing issue.