### PR TITLE
Add a public MCP content-server example

### DIFF
--- a/all_agents_tutorials/mcp-tutorial.ipynb
+++ b/all_agents_tutorials/mcp-tutorial.ipynb
@@ -75,6 +75,8 @@
     "\n",
     "**👉 Try it yourself:** [MCP Quick Start Guide for Users](https://modelcontextprotocol.io/quickstart/user)\n",
     "\n",
+    "**👉 Try a public content server:** [AI Talks](https://aietalks.com) is a free archive of AI Engineer talk summaries. Its read-only [MCP server](https://aietalks.com/mcp) lets compatible hosts search and browse the archive.\n",
+    "\n",
     "By exploring the quick start guide, you'll gain practical insight into what we're building in this tutorial. When you're ready to understand the inner workings and create your own implementations, continue with our step-by-step development process below.\n",
     "\n",
     "Now, let's start building our own MCP server and client!"


### PR DESCRIPTION
Adds a public, read-only MCP content server to the tutorial's existing "Try Before You Build" section, so readers can try a real search-and-browse server before implementing their own.

Disclosure: I maintain AI Talks, a free archive of searchable AI Engineer talk summaries.
