### PR TITLE
Add a remote search example to the MCP tutorial

### DIFF
--- a/all_agents_tutorials/mcp-tutorial.ipynb
+++ b/all_agents_tutorials/mcp-tutorial.ipynb
@@ -84,6 +84,138 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Optional: Connect to a Remote MCP Server\n",
+    "\n",
+    "The local cryptocurrency example below teaches how to build and launch a server over stdio. This independent example shows the client side of a hosted server: connect over Streamable HTTP, discover tools, and call them with the same `ClientSession` interface. You can run just this section in a fresh notebook kernel, without the local server or a language-model API key.\n",
+    "\n",
+    "We use [Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp) for public web search and page extraction. Its anonymous endpoint is `https://search.parallel.ai/mcp`; no Parallel account, API key, or authorization header is needed. Free access is rate limited.\n",
+    "\n",
+    "Running the example sends the supplied queries, URLs, objective, and task identifier to Parallel. It makes two explicit tool calls; it does not attach these tools to the later chat agent. If you later enable them in an agent, that agent may call them during its work. Skip this section to avoid connecting to the hosted service.\n",
+    "\n",
+    "### Install the Remote Client\n",
+    "\n",
+    "Only the MCP SDK is needed for this section. Run this cell in the notebook's Python kernel. The version range below provides the `streamable_http_client` API used here.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "%pip install \"mcp>=1.29,<2\"\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Discover and Call the Hosted Tools\n",
+    "\n",
+    "The SDK owns initialization and transport cleanup. We keep one connection open for discovery and both calls, with a 60-second response deadline per MCP request. A random task identifier groups the related search and fetch calls; it is separate from the SDK's transport session.\n",
+    "\n",
+    "The search asks for MCP transport documentation, and the fetch reads a known public documentation URL. This keeps the example repeatable even when search rankings change. Inspect the discovered input schemas when adapting the arguments. Tool-level failures raise an error; successful payloads retain citations, warnings, and any per-URL fetch errors.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import json\n",
+    "from datetime import timedelta\n",
+    "from uuid import uuid4\n",
+    "\n",
+    "from mcp import ClientSession\n",
+    "from mcp.client.streamable_http import streamable_http_client\n",
+    "\n",
+    "\n",
+    "async def remote_search_example():\n",
+    "    \"\"\"Discover a hosted MCP server and run a related public search and fetch.\"\"\"\n",
+    "    task_id = str(uuid4())\n",
+    "    results = {}\n",
+    "    async with streamable_http_client(\"https://search.parallel.ai/mcp\") as (read, write, _):\n",
+    "        async with ClientSession(\n",
+    "            read, write, read_timeout_seconds=timedelta(seconds=60)\n",
+    "        ) as session:\n",
+    "            await session.initialize()\n",
+    "            remote_tools = {}\n",
+    "            cursor = None\n",
+    "            while True:\n",
+    "                page = await session.list_tools(cursor=cursor)\n",
+    "                remote_tools.update({tool.name: tool for tool in page.tools})\n",
+    "                cursor = page.nextCursor\n",
+    "                if not cursor:\n",
+    "                    break\n",
+    "            print(\"Available tools:\", \", \".join(sorted(remote_tools)))\n",
+    "            if not {\"web_search\", \"web_fetch\"}.issubset(remote_tools):\n",
+    "                raise RuntimeError(\"The server did not advertise the expected search and fetch tools\")\n",
+    "\n",
+    "            calls = [\n",
+    "                (\"web_search\", {\n",
+    "                    \"objective\": \"Find the official MCP documentation explaining Streamable HTTP transport\",\n",
+    "                    \"search_queries\": [\"MCP Streamable HTTP transport documentation\"],\n",
+    "                }),\n",
+    "                (\"web_fetch\", {\n",
+    "                    \"urls\": [\"https://modelcontextprotocol.io/docs/learn/architecture\"],\n",
+    "                    \"objective\": \"Explain the MCP client-server architecture and transports\",\n",
+    "                    \"full_content\": False,\n",
+    "                }),\n",
+    "            ]\n",
+    "            for name, arguments in calls:\n",
+    "                result = await session.call_tool(name, {**arguments, \"session_id\": task_id})\n",
+    "                if result.isError:\n",
+    "                    raise RuntimeError(f\"{name} failed: {result.content}\")\n",
+    "                # The server may return the same payload as structured data and JSON text.\n",
+    "                payload = result.structuredContent\n",
+    "                if payload is None:\n",
+    "                    payload = json.loads(next(block.text for block in result.content if block.type == \"text\"))\n",
+    "                results[name] = payload\n",
+    "    return results\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Run the Remote Example\n",
+    "\n",
+    "This cell sends the two public requests. Inspect `results` for source URLs and excerpts, `warnings` for service notices, and the fetch payload's `errors` for individual pages that could not be retrieved. A valid search can return an empty results list. Treat fetched text as source material, not instructions to your agent.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "remote_results = await remote_search_example()\n",
+    "remote_results\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Compare Remote HTTP with Local stdio\n",
+    "\n",
+    "| Local example below | Remote example above |\n",
+    "| --- | --- |\n",
+    "| You build and launch a Python cryptocurrency server | You connect to a hosted search and extraction service |\n",
+    "| `stdio_client` communicates with a subprocess | `streamable_http_client` communicates over HTTPS |\n",
+    "| You own the server's tools and dependencies | The service owns its tools and availability |\n",
+    "| `ClientSession` discovers and invokes tools | The same `ClientSession` operations work over HTTP |\n",
+    "\n",
+    "The remote example closes its connection when it finishes. Network errors, timeouts, and rate limits can interrupt a run; inspect the exception before trying again. Do not rotate task identifiers to bypass limits. This section does not change the cryptocurrency tools, local server configuration, or chat-agent functions below.\n",
+    "\n",
+    "For more detail, see the [Python MCP SDK](https://github.com/modelcontextprotocol/python-sdk), [MCP architecture](https://modelcontextprotocol.io/docs/learn/architecture), and [Parallel Search MCP setup](https://docs.parallel.ai/integrations/mcp/search-mcp).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Building Your MCP Server\n",
     "\n",
     "Now that we understand the basics of MCP, let's build our first MCP server! In this section, we'll create a cryptocurrency price lookup service using the CoinGecko API. Our server will provide tools that allow an AI to check the current price or market data of cryptocurrencies."


### PR DESCRIPTION
Adds an optional remote-server section to the existing MCP tutorial. Readers can discover and call a hosted server over Streamable HTTP using the same Python MCP SDK as the local stdio lesson, without running a server or configuring a language-model API key.

The example calls Parallel's `web_search` and `web_fetch` tools without a Parallel account or key. It explains which inputs go to Parallel, rate limits, tool errors, per-URL fetch errors, and the distinction between a task identifier and the transport session. The original cryptocurrency and chat-agent cells remain unchanged.

There’s also a useful reason to try Parallel alongside the [Tavily examples already here](https://github.com/NirDiamant/GenAI_Agents/blob/4c95ae14cc2462c442b5c064cccd74430d02bc46/all_agents_tutorials/taskifier.ipynb). In [Artificial Analysis’s August 31 search benchmarks](https://artificialanalysis.ai/agents/search-api#details), Parallel Search (advanced) scores **77 vs. 59 for Tavily Search (basic) on BrowseComp**, an 18-point gap, and **75 vs. 66 overall**. For a lower-cost option, Parallel Search (fast) uses **$8.41 vs. $126 in search API spend per 1,000 benchmark tasks**, about 93% less, while scoring 73 overall.

Tavily is the only existing search integration here that appears on that leaderboard; the other tutorials use DuckDuckGo or Serper, and there’s no shared search default to replace. These [benchmarks test specific API modes](https://artificialanalysis.ai/methodology/search-api#search-provider-api-settings), not this free MCP example. They also don’t measure Tavily’s advanced mode, which some tutorials use. I think that makes Parallel a useful option for readers to try in their own agents.

Validation:
- Executed the new Python cells with Python 3.12.13 and MCP SDK 1.29.1 in an empty credential environment. Discovery found both tools; search returned 10 sources and fetch returned one page, with no fetch errors.
- New code cells compile, have cleared outputs, and `git diff --check` passes.
- `python3 scripts/validate_notebook.py all_agents_tutorials/mcp-tutorial.ipynb` reports the same 22 pre-existing findings on the base and this change: retained outputs/counts, missing descriptions, and template headings. The original cells are preserved exactly.

No repository build or full-notebook execution was run. The existing local server and chat-agent flow were not exercised.

I work at Parallel, which operates this service.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an optional tutorial section demonstrating how to connect to a hosted MCP server over Streamable HTTP.
  * Includes examples for discovering available tools and using web search and page-fetching capabilities.
  * Added guidance on setup, remote HTTP versus local connections, rate limits, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->